### PR TITLE
Add ability to add notes via form

### DIFF
--- a/app/blueprints/notes/views.py
+++ b/app/blueprints/notes/views.py
@@ -3,7 +3,7 @@
 Notes views
 """
 
-from flask import Blueprint, render_template
+from flask import Blueprint, redirect, render_template, request, url_for
 from sqlalchemy import desc
 
 from app.blueprints.notes.models import Note
@@ -16,3 +16,13 @@ notes = Blueprint('notes', __name__)
 def list():
     all_notes = Note.query.order_by(desc(Note.updated)).all()
     return render_template('notes/list.html', notes=all_notes)
+
+
+@notes.route('/notes', methods=['POST'])
+def add():
+    content = request.form.get('content', '').strip()
+
+    if content:
+        Note.create(content)
+
+    return redirect(url_for('.list'))

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,8 @@ ASSETS_DEBUG = False
 
 DEBUG = bool(env.get('DEBUG', True))
 
+HUMANIZE_USE_UTC = True
+
 SECRET_KEY = env.get('SECRET_KEY', os.urandom(24))
 
 SESSION_COOKIE_SECURE = False

--- a/app/templates/notes/list.html
+++ b/app/templates/notes/list.html
@@ -17,7 +17,7 @@
         <button class="button">Save</button>
       </form>
     </section>
-    <span class="note-date" itemprop="dateModified" data-timestamp="{{ note.updated.timestamp() }}">
+    <span class="note-date" itemprop="dateModified" data-timestamp="{{ note.updated.strftime('%Y%m%d%H%M%S.%f') }}">
       {{ note.updated|humanize() }}
     </span>
     <span class="undo-link">Just updated (<a href="">undo</a>)</span>
@@ -46,7 +46,7 @@
     #}
   </div>
 
-  <form action="" class="form note-form add-note-form">
+  <form action="{{ url_for('notes.add') }}" method="post" class="form note-form add-note-form">
     <textarea name="content" rows="1" placeholder="Write a note &hellip;"></textarea>
     <button class="button">Save</button>
   </form>

--- a/tests/spec/test_add_note.py
+++ b/tests/spec/test_add_note.py
@@ -1,0 +1,32 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+import pytest
+
+
+@pytest.fixture
+def form_submit(client):
+    return client.post(url_for('notes.add'), data={
+        'content': 'A *lovely* new note'})
+
+
+@pytest.fixture
+def follow_redirect(client, form_submit):
+    return client.get(form_submit.headers['Location'])
+
+
+@pytest.fixture
+def soup(follow_redirect):
+    return BeautifulSoup(follow_redirect.get_data(as_text=True), 'html.parser')
+
+
+@pytest.mark.use_fixtures('db_session', 'form_submit')
+class TestWhenAddingANewNote(object):
+
+    def test_it_redirects_to_the_list_view(self, db_session, form_submit):
+        assert form_submit.status_code == 302
+        assert url_for('notes.list') in form_submit.headers['Location']
+
+    def test_it_updates_the_list_view(self, db_session, soup):
+        notes = soup.find_all(class_='note')
+        assert len(notes) > 0
+        assert 'A <em>lovely</em> new note' in str(notes[0].find(itemprop='text'))


### PR DESCRIPTION
## What
- Added new view to notes blueprint to receive form POSTs to `/notes`
- Added tests that submitting the form redirects the user to the updated list of notes
- Set flask-humanize config to show time elapsed using UTC, because it was showing "1 hour ago" for just-added notes
- Changed `data-timestamp` attribute on note time since last update to use `YYYYmmDDHHMMSS.ffffff` format instead of seconds since UNIX epoch - easier to read and future-proof
## How to review
1. Follow the instructions in README.md to run the app
2. Browse to [http://localhost:5000/notes](http://localhost:5000/notes)
3. Click on the "Write a note &hellip;" input
4. Type a note
5. Click on "Save"
6. Be redirected to the updated list of notes
## Who can review

Not @andyhd
