### PR TITLE
Add tip message about emailing notes

### DIFF
--- a/app/templates/notes/list.html
+++ b/app/templates/notes/list.html
@@ -34,16 +34,17 @@
   <div class="test">
     <h1 class="heading-large">Notes</h1>
 
-    {#
+    {% if show_tip %}
     <div class="message-box">
       <h3 class="heading-small">You can also email notes in to the service</h3>
       <p>
-        Use <a href="">{{ current_user.inbox_email }}</a>.
+        Use <a href="mailto:{{ inbox_email }}">{{ inbox_email }}</a>.
         Check your settings for more details.
       </p>
-      <span class="dismiss">Dismiss</span>
+      <span class="dismiss"><a href="{{ url_for('notes.dismiss_tip') }}">Dismiss</a></span>
     </div>
-    #}
+    {% endif %}
+
   </div>
 
   <form action="{{ url_for('notes.add') }}" method="post" class="form note-form add-note-form">


### PR DESCRIPTION
## What
- Updated list view to check for `seen_email_tip` cookie - incremented on each view
- Updated list template to show email tip if cookie value is less than 2
- Added view for dismissing email tip, which sets cookie value to 2
- Tests
## How to review
1. Setup app as per README instructions
2. Clear your cookies
3. Browse to [http://localhost:5000/notes](http://localhost:5000/notes)
4. See the email tip at the top of the notes list
5. Click on "Dismiss" - The tip will be removed
6. Clear your cookies and refresh, the tip will return
7. Refresh twice more, the tip will be removed
## Who can review

Anyone except @andyhd
