### PR TITLE
Tidy up spec tests and py.test invocation

### DIFF
--- a/app/blueprints/healthcheck/views.py
+++ b/app/blueprints/healthcheck/views.py
@@ -12,10 +12,6 @@ healthcheck = Blueprint('healthcheck', __name__)
 @healthcheck.route('/healthcheck.json')
 def check_health():
     status = {
-        # 'database': False,
-        # 'migrations': False,
-        # 'mail': False,
-        # 'cache': False,
         'site': True}
 
     code = 200

--- a/manage.py
+++ b/manage.py
@@ -20,7 +20,7 @@ manager.add_command('db', MigrateCommand)
 
 
 def run_tests(module=None, *args):
-    argv = ['-q', '--flakes', '--mccabe', '--pep8', '--spec']
+    argv = []
 
     if module:
         argv.extend(['--pyargs', module])
@@ -33,7 +33,7 @@ def run_tests(module=None, *args):
 
 @manager.command
 def test():
-    run_tests('tests.spec')
+    run_tests('tests.spec', '--spec')
 
 
 @manager.command

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
-flakes-ignore =
-    tests/*.py UnusedImport  # pytest fixture imports trigger this
+addopts=-q --ignore=migrations --eradicate --flake8
+python_classes=When
+python_functions=it_*

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,9 @@ libsass
 markdown
 pytest
 pytest-cov
-pytest-flakes
+pytest-eradicate
+pytest-flake8
 pytest-flask
-pytest-mccabe
-pytest-pep8
 pytest-spec
 raven
 requests

--- a/tests/spec/test_add_note.py
+++ b/tests/spec/test_add_note.py
@@ -19,14 +19,15 @@ def soup(follow_redirect):
     return BeautifulSoup(follow_redirect.get_data(as_text=True), 'html.parser')
 
 
-@pytest.mark.use_fixtures('db_session', 'form_submit')
-class TestWhenAddingANewNote(object):
+class WhenAddingANewNote(object):
 
-    def test_it_redirects_to_the_list_view(self, db_session, form_submit):
+    def it_redirects_to_the_list_view(self, db_session, form_submit):
         assert form_submit.status_code == 302
         assert url_for('notes.list') in form_submit.headers['Location']
 
-    def test_it_updates_the_list_view(self, db_session, soup):
+    def it_updates_the_list_view(self, db_session, soup):
         notes = soup.find_all(class_='note')
         assert len(notes) > 0
-        assert 'A <em>lovely</em> new note' in str(notes[0].find(itemprop='text'))
+
+        content = str(notes[0].find(itemprop='text'))
+        assert 'A <em>lovely</em> new note' in content

--- a/tests/spec/test_assets.py
+++ b/tests/spec/test_assets.py
@@ -7,9 +7,8 @@ def response(client):
     return client.get(url_for('base.index'))
 
 
-@pytest.mark.use_fixtures('response')
-class TestWhenRenderingAPage(object):
+class WhenRenderingAPage(object):
 
-    def test_it_uses_govuk_elements(self, response):
+    def it_uses_govuk_elements(self, response):
         assert '/static/stylesheets/govuk_elements.css' in \
             response.get_data(as_text=True)

--- a/tests/spec/test_config.py
+++ b/tests/spec/test_config.py
@@ -3,9 +3,9 @@ from unittest.mock import patch
 from app.factory import create_app
 
 
-class TestWhenDeployedInAWS(object):
+class WhenDeployedInAWS(object):
 
-    def test_it_fetches_secrets_from_credstash(self):
+    def it_fetches_secrets_from_credstash(self):
 
         patcher = patch('lib.aws_env.env.__getitem__')
         get = patcher.start()

--- a/tests/spec/test_healthcheck.py
+++ b/tests/spec/test_healthcheck.py
@@ -7,11 +7,10 @@ def response(client):
     return client.get(url_for('healthcheck.check_health'))
 
 
-@pytest.mark.use_fixtures('response')
-class TestWhenBrowsingToHealthcheckEndpoint(object):
+class WhenBrowsingToHealthcheckEndpoint(object):
 
-    def test_it_exists(self, response):
+    def it_exists(self, response):
         assert response.status_code == 200
 
-    def test_it_reports_site_ok(self, response):
+    def it_reports_site_ok(self, response):
         assert response.json['site'] is True

--- a/tests/spec/test_hello.py
+++ b/tests/spec/test_hello.py
@@ -7,8 +7,7 @@ def response(client):
     return client.get(url_for('base.index'))
 
 
-@pytest.mark.use_fixtures('response')
-class TestWhenBrowsingToIndexPage(object):
+class WhenBrowsingToIndexPage(object):
 
-    def test_it_shows_hello_world(self, response):
+    def it_shows_hello_world(self, response):
         assert 'Hello World!' in response.get_data(as_text=True)

--- a/tests/spec/test_list_notes.py
+++ b/tests/spec/test_list_notes.py
@@ -53,10 +53,9 @@ def dismiss_tip(client):
     return client.get(url_for('notes.dismiss_tip'))
 
 
-@pytest.mark.use_fixtures('seen_twice_already', 'soup')
-class TestWhenViewingNotesListPage(object):
+class WhenViewingNotesListPage(object):
 
-    def test_it_lists_notes_in_reverse_chronological_order(self, soup):
+    def it_lists_notes_in_reverse_chronological_order(self, soup):
         notes = soup.find_all(class_='note')
         assert len(notes) == 3
 
@@ -66,35 +65,35 @@ class TestWhenViewingNotesListPage(object):
         assert timestamp(notes[0]) >= timestamp(notes[1])
         assert timestamp(notes[1]) >= timestamp(notes[2])
 
-    def test_it_renders_note_contents_as_markdown(self, soup):
+    def it_renders_note_contents_as_markdown(self, soup):
         note = soup.find_all(class_='note')[0]
         assert len(note.find_all('em')) > 0
 
-    def test_it_shows_only_the_first_250_characters_of_a_note(self, soup):
+    def it_shows_only_the_first_250_characters_of_a_note(self, soup):
         notes = soup.find_all(class_='note')
         for note in notes:
             assert len(Markup(note.find(itemprop='text')).striptags()) <= 250
 
-    def test_it_shows_the_email_tip(self, soup):
+    def it_shows_the_email_tip(self, soup):
         tip = soup.find(class_='message-box')
         assert tip.find('a')['href'].startswith('mailto:')
 
-    def test_it_sets_a_cookie_if_it_has_been_seen_twice_already(
+    def it_sets_a_cookie_if_it_has_been_seen_twice_already(
             self, seen_twice_already):
         cookies = SimpleCookie()
         cookies.load(seen_twice_already.headers.get('Set-Cookie'))
         assert 'seen_email_tip' in cookies
         assert int(cookies['seen_email_tip'].value) == 2
 
-    def test_it_hides_the_email_tip_if_it_has_been_seen_twice_already(
+    def it_hides_the_email_tip_if_it_has_been_seen_twice_already(
             self, seen_twice_already_soup):
         tip = seen_twice_already_soup.find(class_='message-box')
         assert tip is None
 
 
-class TestWhenDismissingTheEmailTip(object):
+class WhenDismissingTheEmailTip(object):
 
-    def test_it_sets_a_cookie(self, dismiss_tip):
+    def it_sets_a_cookie(self, dismiss_tip):
         cookies = SimpleCookie()
         cookies.load(dismiss_tip.headers.get('Set-Cookie'))
         assert 'seen_email_tip' in cookies

--- a/tests/spec/test_notes.py
+++ b/tests/spec/test_notes.py
@@ -1,12 +1,9 @@
-import pytest
-
 from app.blueprints.notes.models import Note
 
 
-@pytest.mark.use_fixtures('app', 'db')
-class TestWhenUpdatingANote(object):
+class WhenUpdatingANote(object):
 
-    def test_it_stores_the_previous_version(self, db_session):
+    def it_stores_the_previous_version(self, db_session):
         note = Note.create('Test note')
         assert len(note.history) == 0
 
@@ -17,10 +14,9 @@ class TestWhenUpdatingANote(object):
         assert note.history[0].version == 1
 
 
-@pytest.mark.use_fixtures('app', 'db')
-class TestWhenANoteHasHistory(object):
+class WhenANoteHasHistory(object):
 
-    def test_it_can_be_reverted_to_a_previous_version(self, db_session):
+    def it_can_be_reverted_to_a_previous_version(self, db_session):
         note = Note.create('Test note')
         note.update('Test note edited')
         note.update('Test note edited again')


### PR DESCRIPTION
## What
- Changed tests discovery pattern to `When*` for classes and `it_*` for methods/functions to remove redundant `Test`/`test_` prefix and make spec tests more fluent
- Replaced `pytest-flakes`, `pytest-mccabe` and `pytest-pep8` with `pytest-flake8`, which supercedes them
- Added `pytest-eradicate` which fails on finding commented-out code blocks
- Fixed a too-long line and removed a commented-out code block
## How to review
1. Follow instructions in README.md to stup the app
2. Run the tests with `python manage.py test`
## Who can review

Anyone but @andyhd
