### PR TITLE
Add some basic extensions to Markdown

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,13 @@ DEBUG = bool(env.get('DEBUG', True))
 
 HUMANIZE_USE_UTC = True
 
+MARKDOWN_EXTENSIONS = [
+    'markdown.extensions.nl2br',
+    'markdown.extensions.sane_lists',
+    'markdown.extensions.smart_strong',
+    'markdown.extensions.smarty',
+]
+
 SECRET_KEY = env.get('SECRET_KEY', os.urandom(24))
 
 SESSION_COOKIE_SECURE = False

--- a/app/factory.py
+++ b/app/factory.py
@@ -93,7 +93,7 @@ def register_extensions(app):
     Migrate().init_app(app, db)
 
     from flaskext.markdown import Markdown
-    Markdown(app)
+    Markdown(app, extensions=app.config.get('MARKDOWN_EXTENSIONS', []))
 
     from flask.ext.humanize import Humanize
     Humanize(app)


### PR DESCRIPTION
## What
- Added `nl2br`, `sane_lists`, `smart_strong` and `smarty` Markdown extensions, to better render notes
## How to review
1. Run the app as per README.md
2. Browse to http://localhost:5000/notes
3. Write a new note with the following content:
   
   > These quotes should be "smart"
   > This should be rendered on a new line
   > There should be no emphasis in THIS__STRING
   > &nbsp;1. The first two items should
   > &nbsp;2. be in an ordered list
   > 
   > &nbsp;\* The last two should be
   > &nbsp;\* in an unordered list

(note the spaces before the list item numbers)
The note should be rendered correctly
## Who can review

Anyone but @andyhd
