### PR TITLE
Remove HTML tags from user input

### DIFF
--- a/app/blueprints/notes/models.py
+++ b/app/blueprints/notes/models.py
@@ -5,6 +5,8 @@ Notes models
 
 import datetime
 
+from bs4 import BeautifulSoup
+
 from app.extensions import db
 
 
@@ -24,10 +26,16 @@ class Note(db.Model):
                     version,
                     note.id))
 
+    def set_content(self, content):
+        soup = BeautifulSoup(content)
+        nodes = soup.recursiveChildGenerator()
+        text_nodes = [e for e in nodes if isinstance(e, str)]
+        self.content = ''.join(text_nodes)
+
     @classmethod
     def create(cls, content, is_email=False):
         note = Note()
-        note.content = content
+        note.set_content(content)
         note.created = datetime.datetime.utcnow()
         note.updated = note.created
         note.is_email = is_email
@@ -40,7 +48,7 @@ class Note(db.Model):
         version = NoteHistory(self, now)
         db.session.add(version)
         self.history.append(version)
-        self.content = content
+        self.set_content(content)
         self.updated = now
         db.session.add(self)
         db.session.commit()

--- a/tests/spec/test_notes.py
+++ b/tests/spec/test_notes.py
@@ -13,6 +13,16 @@ class WhenUpdatingANote(object):
         assert note.history[0].content == 'Test note'
         assert note.history[0].version == 1
 
+    def it_strips_html_tags_from_the_user_input(self, db_session):
+        note = Note.create('<script>alert("bad things")</script>')
+        assert note.content == 'alert("bad things")'
+
+        note.update('<form action="evil.com/phish"><input name="cc"></form>')
+        assert note.content == ''
+
+        note.update('<p style="color: pink">woo!</p>')
+        assert note.content == 'woo!'
+
 
 class WhenANoteHasHistory(object):
 


### PR DESCRIPTION
## What
- Strip HTML tags from user input to prevent injection attacks
## How to review
1. Setup and run the app per README instructions
2. Browse to [http://localhost:5000/notes](http://localhost:5000/notes)
3. Write a new note with a script tag, eg:
   
   > &lt;script>alert("bad things")&lt;/script>
4. Save the note and see that no Javascript is executed, and the content of the note is:
   
   > alert("bad things")
## Who can review

Anyone but @andyhd
