### PR TITLE
Replace 3rd party html truncation lib with one that works

### DIFF
--- a/app/blueprints/notes/models.py
+++ b/app/blueprints/notes/models.py
@@ -27,7 +27,7 @@ class Note(db.Model):
                     note.id))
 
     def set_content(self, content):
-        soup = BeautifulSoup(content)
+        soup = BeautifulSoup(content, 'html.parser')
         nodes = soup.recursiveChildGenerator()
         text_nodes = [e for e in nodes if isinstance(e, str)]
         self.content = ''.join(text_nodes)

--- a/app/factory.py
+++ b/app/factory.py
@@ -104,7 +104,7 @@ def register_filters(app):
     Import and register Jinja filters
     """
 
-    from html5lib_truncation import truncate_html
+    from lib.html_truncation import truncate_html
     from markupsafe import Markup
 
     def truncate(*args, **kwargs):

--- a/lib/html_truncation.py
+++ b/lib/html_truncation.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+Truncate HTML to character limit, preserving well formedness
+"""
+
+from html.parser import HTMLParser
+
+
+def truncate_words(text, max_chars, break_words=False, padding=0):
+    """
+    Truncate a string to max_chars, optionally truncating words
+    """
+
+    if break_words:
+        return text[:-abs(max_chars - len(text)) - padding]
+
+    words = []
+    for word in text.split():
+        length = sum(map(len, words)) + len(word) + len(words) - 1 + padding
+        if length >= max_chars:
+            break
+        words.append(word)
+
+    return ' '.join(words)
+
+
+class TruncatingParser(HTMLParser):
+    """
+    Parse HTML and output a truncated version
+    """
+
+    def __init__(self, max_chars, end='', break_words=False):
+        super(TruncatingParser, self).__init__()
+        self.max_chars = max_chars
+        self.num_chars = 0
+        self.end = end
+        self.break_words = break_words
+        self.depth = 0
+        self.odepth = 0
+        self.output = ''
+
+    @property
+    def overflow(self):
+        return self.num_chars + len(self.end) > self.max_chars
+
+    def handle_starttag(self, tag, attrs):
+        if self.overflow:
+            self.odepth += 1
+
+        else:
+            self.depth += 1
+            self.output_start(tag, attrs)
+
+    def handle_endtag(self, tag):
+        if self.depth > 0 and self.odepth == 0:
+            self.depth -= 1
+            self.output_end(tag)
+        else:
+            self.odepth -= 1
+
+    def handle_startendtag(self, tag, attrs):
+        if self.overflow:
+            self.odepth += 1
+
+        else:
+            self.depth += 1
+
+        if self.depth > 0 and self.odepth == 0:
+            self.depth -= 1
+            self.output_startend(tag, attrs)
+
+        else:
+            self.odepth -= 1
+
+    def handle_data(self, data):
+        self.num_chars += len(data)
+
+        if self.overflow:
+            overflow_chars = self.num_chars - self.max_chars + len(self.end)
+            data = truncate_words(
+                data,
+                len(data) - overflow_chars,
+                break_words=self.break_words,
+                padding=len(self.end))
+
+            if data:
+                data += self.end
+
+        self.output_data(data)
+
+    def output_start(self, tag, attrs, self_closing=False):
+        self.output += '<{}{}{}>'.format(
+            tag,
+            ' '.join('='.join(pair) for pair in attrs),
+            ' /' if self_closing else '')
+
+    def output_end(self, tag):
+        self.output += '</{}>'.format(tag)
+
+    def output_startend(self, tag, attrs):
+        self.output_start(tag, attrs, self_closing=True)
+
+    def output_data(self, data):
+        if data:
+            self.output += data
+
+
+def truncate_html(html, max_chars, end='', break_words=False):
+    """
+    Truncate an HTML string to specified character limit, preserving
+    well-formedness
+    """
+
+    parser = TruncatingParser(max_chars, end=end, break_words=break_words)
+    parser.feed('<div>{}</div>'.format(html))
+    return parser.output[5:-6]

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,6 @@ flask-script
 flask-security
 flask-sqlalchemy
 flask-wtf
-html5lib-truncation
 libsass
 markdown
 pytest

--- a/tests/spec/test_html_truncation.py
+++ b/tests/spec/test_html_truncation.py
@@ -1,0 +1,31 @@
+from bs4 import BeautifulSoup
+from lib.html_truncation import truncate_html
+
+import pytest
+
+
+@pytest.fixture
+def no_html():
+    return 'All work and no play makes Jack a dull boy. ' * 10
+
+
+@pytest.fixture
+def unordered_list():
+    li = '<li>All work and no play makes Jack a dull boy. </li>'
+    return '<ul>{}</ul>'.format(li * 10)
+
+
+class WhenHTMLTextIsLongerThanSpecifiedMax(object):
+
+    def it_truncates_text_ignoring_tags_whole_words_to_max(self, no_html):
+        assert len(truncate_html(no_html, 250)) == 246
+
+    def it_truncates_html_keeping_well_formedness(self, unordered_list):
+        truncated = truncate_html(unordered_list, 250)
+        soup = BeautifulSoup(truncated, 'html.parser')
+        assert len(soup.text) == 246
+        assert len(soup.find_all('ul')) == 1
+        assert len(soup.find_all('li')) == 6
+
+    def it_appends_an_ellipsis_to_truncated_text(self, no_html):
+        assert truncate_html(no_html, 250, end='...').endswith('...')


### PR DESCRIPTION
## What
- Removed `html5lib-truncation` dependency, as it has some faults and depends on html5lib
- Added new HTML truncation module, which uses `html.parser` and meets our requirements
## How to review
1. Setup and run the app as per README instructions
2. Browse to [http://localhost:5000/notes](http://localhost:5000/notes)
3. Write a new note with Markdown and over 250 characters, eg:
   
   ```
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   ```
4. Save the note and see that it has been truncated to ~250 chars, with no broken or missing markup and no extra markup beyond the truncation point, eg:
   
   > - All work and no play makes Jack a dull boy
   > - All work and no play makes Jack a dull boy
   > - All work and no play makes Jack a dull boy
   > - All work and no play makes Jack a dull boy
   > - All work and no play makes Jack a dull boy
   > - All work and no play&hellip;
## Who can review

Anyone but @andyhd
