### PR TITLE
Add groundwork for Selenium UI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 - Python 3
 - Ruby 2.2.0 (for `govuk_template`)
+- PhantomJS (for UI testing)
 
 
 ## Quickstart
@@ -30,40 +31,28 @@
 
 To run fast unit tests:
 ```
-python manage.py test
+python manage.py test spec
 ```
 
 To run smoke tests:
 ```
-python manage.py smoketest
+python manage.py test smoke
+```
+
+To run UI tests:
+```
+python manage.py test ui
 ```
 
 To run all tests:
 ```
-python manage.py all_tests
+python manage.py test
 ```
 
 To generate HTML coverage reports (in the `htmlcov` directory)
 ```
-python manage.py coverage
+python manage.py test coverage
 ```
-
-
-## Development
-
-### Requirements
-
-If you depend on Python modules that are not needed in production (eg: ipython),
-you may use a `local_requirements.txt` file which is not stored in version
-control. Set the first line of this file to
-```
--r requirements.txt
-```
-to add all the production dependencies. That way, you will only need to run
-```
-pip install -r local_requirements.txt
-```
-to install all requirements.
 
 
 ## Deployment

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts=-q --ignore=migrations --eradicate --flake8
+addopts=-q --ignore=migrations --eradicate --flake8 --driver=PhantomJS
 python_classes=When
 python_functions=it_*

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,7 @@ pytest-cov
 pytest-eradicate
 pytest-flake8
 pytest-flask
+pytest-selenium
 pytest-spec
 raven
 requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,9 @@ def db_session(db, request):
     request.addfinalizer(teardown)
 
     return session
+
+
+@pytest.fixture
+def selenium(db, live_server, selenium):
+    """Override selenium fixture to always use flask live server"""
+    return selenium

--- a/tests/smoke/test_app.py
+++ b/tests/smoke/test_app.py
@@ -4,8 +4,8 @@ import requests
 
 
 @pytest.mark.use_fixtures('live_server')
-class TestApplication(object):
+class WhenApplicationIsUp(object):
 
-    def test_app_ready(self, live_server):
+    def it_returns_HTTP_200_for_the_index_page(self, live_server):
         r = requests.get(url_for('base.index', _external=True))
         assert 200 == r.status_code


### PR DESCRIPTION
## What
- Add `pytest-selenium` to enable writing Selenium tests
- Refactored `manage.py` test commands to allow specifying type of tests to run
## How to review
1. Setup the app as per README instructions
2. Run `python manage.py test --help` to see the options for running tests
3. Run `python manage.py test spec` to run fast spec tests
4. Run `python manage.py test smoke` to run smoke tests
5. Run `python manage.py test coverage` to generate an HTML test coverage report
6. Run `python manage.py test ui` to run Selenium tests (none included yet)
7. Run `python manage.py test` or `python manage.py test all` to run all tests
## Who can review

Not @andyhd
