### PR TITLE
Remove undo link after 2 min delay

### DIFF
--- a/app/blueprints/notes/views.py
+++ b/app/blueprints/notes/views.py
@@ -3,6 +3,8 @@
 Notes views
 """
 
+import datetime
+
 from flask import (
     Blueprint,
     after_this_request,
@@ -21,6 +23,7 @@ notes = Blueprint('notes', __name__)
 @notes.route('/notes')
 def list():
     all_notes = Note.query.order_by(desc(Note.updated)).all()
+    two_mins_ago = datetime.datetime.utcnow() - datetime.timedelta(minutes=2)
 
     times_seen = int(request.cookies.get('seen_email_tip', 0))
     show_tip = times_seen < 2
@@ -40,7 +43,8 @@ def list():
         'notes/list.html',
         notes=all_notes,
         inbox_email='your-inbox@civilservice.digital',
-        show_tip=show_tip)
+        show_tip=show_tip,
+        undo_timeout=two_mins_ago)
 
 
 @notes.route('/notes', methods=['POST'])

--- a/app/templates/notes/list.html
+++ b/app/templates/notes/list.html
@@ -17,7 +17,7 @@
         <button class="button">Save</button>
       </form>
     </section>
-    {% if note.history -%}
+    {% if note.history and note.updated > undo_timeout -%}
     <form action="{{ url_for('notes.undo', id=note.id) }}" method="post" class="undo-link">
       Just updated (<button>undo</button>)
     </form>

--- a/tests/ui/test_undo_link.py
+++ b/tests/ui/test_undo_link.py
@@ -1,5 +1,10 @@
+import contextlib
+import datetime
+from mock import patch
+
 from flask import url_for
 import pytest
+from selenium.common.exceptions import NoSuchElementException
 
 from app.blueprints.notes.models import Note
 
@@ -9,6 +14,14 @@ def updated_note(db_session):
     note = Note.create('Original text')
     note.update('Updated text')
     return note
+
+
+@contextlib.contextmanager
+def utcnow(module, value):
+    with patch(module) as dt:
+        dt.utcnow.return_value = value
+        dt.side_effect = datetime.datetime
+        yield
 
 
 class WhenANoteHasBeenUpdated(object):
@@ -26,3 +39,23 @@ class WhenANoteHasBeenUpdated(object):
         selenium.find_element_by_css_selector('.add-note-form').click()
 
         assert not undo_link.is_displayed()
+
+    def it_hides_the_undo_link_after_a_specified_period(
+            self, db_session, updated_note, selenium):
+
+        now = datetime.datetime(2016, 4, 11, 13, 0, 0)
+        two_mins_ago = now - datetime.timedelta(minutes=7)
+
+        with utcnow('app.blueprints.notes.models.datetime.datetime', now):
+            updated_note.updated = two_mins_ago
+            db_session.add(updated_note)
+            db_session.commit()
+
+        with utcnow('app.blueprints.notes.views.datetime.datetime', now):
+            selenium.get(url_for('notes.list', _external=True))
+
+        note = selenium.find_element_by_css_selector(
+            '.note[data-id="{}"]'.format(updated_note.id))
+
+        with pytest.raises(NoSuchElementException):
+            note.find_element_by_class_name('undo-link')


### PR DESCRIPTION
## What
- Hide undo link after 2 mins have passed since last update
## How to review
1. Setup and run app as per README instructions
2. Browse to [http://localhost:5000/notes](the notes page)
3. Write a note
4. Edit the note
5. Wait 2 minutes
6. Refresh the page
7. The undo link is no longer displayed
## Who can review

Anyone but @andyhd
