### PR TITLE
Replace Selenium with Splinter for UI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ coverage.xml
 *,cover
 .hypothesis/
 .testmondata
+screenshots/
 
 # Translations
 *.mo

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-addopts=-q --ignore=migrations --eradicate --flake8 --driver=PhantomJS
+addopts=-q --ignore=migrations --eradicate --flake8 --splinter-webdriver=phantomjs --splinter-implicit-wait=0 --splinter-screenshot-dir=screenshots
 python_classes=When
 python_functions=it_*

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytest-cov
 pytest-eradicate
 pytest-flake8
 pytest-flask
-pytest-selenium
 pytest-spec
+pytest-splinter
 raven
 requests

--- a/tests/ui/test_undo_link.py
+++ b/tests/ui/test_undo_link.py
@@ -4,7 +4,6 @@ from mock import patch
 
 from flask import url_for
 import pytest
-from selenium.common.exceptions import NoSuchElementException
 
 from app.blueprints.notes.models import Note
 
@@ -27,21 +26,21 @@ def utcnow(module, value):
 class WhenANoteHasBeenUpdated(object):
 
     def it_has_an_undo_link_until_the_user_clicks_away(
-            self, updated_note, selenium):
+            self, live_server, updated_note, browser):
 
-        selenium.get(url_for('notes.list', _external=True))
+        browser.visit(url_for('notes.list', _external=True))
 
-        undo_link = selenium.find_element_by_css_selector(
-            '.notes-list .note:first-of-type .undo-link')
+        undo_link = browser.find_by_css(
+            '.notes-list .note:first-of-type .undo-link').first
 
-        assert undo_link.is_displayed()
+        assert undo_link.visible
 
-        selenium.find_element_by_css_selector('.add-note-form').click()
+        browser.find_by_css('.add-note-form').first.click()
 
-        assert not undo_link.is_displayed()
+        assert not undo_link.visible
 
     def it_hides_the_undo_link_after_a_specified_period(
-            self, db_session, updated_note, selenium):
+            self, db_session, live_server, updated_note, browser):
 
         now = datetime.datetime(2016, 4, 11, 13, 0, 0)
         two_mins_ago = now - datetime.timedelta(minutes=7)
@@ -52,10 +51,9 @@ class WhenANoteHasBeenUpdated(object):
             db_session.commit()
 
         with utcnow('app.blueprints.notes.views.datetime.datetime', now):
-            selenium.get(url_for('notes.list', _external=True))
+            browser.visit(url_for('notes.list', _external=True))
 
-        note = selenium.find_element_by_css_selector(
-            '.note[data-id="{}"]'.format(updated_note.id))
+        note = browser.find_by_css(
+            '.note[data-id="{}"]'.format(updated_note.id)).first
 
-        with pytest.raises(NoSuchElementException):
-            note.find_element_by_class_name('undo-link')
+        assert not note.find_by_css('.undo-link')


### PR DESCRIPTION
## What
- Replaced Selenium with Splinter, which has a much simpler API
## How to review
1. See [UI tests](tests/ui/test_undo_link.py) using more readable Splinter API
## Who can review

Not @andyhd
