### PR TITLE
Avoid showing edit mode when clicking on undo-link

### DIFF
--- a/app/static/js/notesapp.js
+++ b/app/static/js/notesapp.js
@@ -43,6 +43,10 @@
     $('body').on('click', function () {
       $('.undo-link').hide().next('.note-date').removeClass('hidden');
     });
+
+    $('.undo-link').on('click', function (event) {
+      event.stopPropagation();
+    });
   });
 
 }).call(this, jQuery, window);

--- a/app/templates/notes/list.html
+++ b/app/templates/notes/list.html
@@ -21,8 +21,8 @@
     <form action="{{ url_for('notes.undo', id=note.id) }}" method="post" class="undo-link">
       Just updated (<button>undo</button>)
     </form>
-    {%- endif -%}
-    <span class="note-date {%- if note.history %} hidden{% endif %}" itemprop="dateModified" data-timestamp="{{ note.updated.strftime('%Y%m%d%H%M%S.%f') }}">
+    {%- endif %}
+    <span class="note-date {%- if note.history and note.updated > undo_timeout %} hidden{% endif %}" itemprop="dateModified" data-timestamp="{{ note.updated.strftime('%Y%m%d%H%M%S.%f') }}">
       {{ note.updated|humanize() }}
     </span>
     {% if note.is_email %}


### PR DESCRIPTION
## What
- Stop event propagation on clicking an undo-link so that edit-mode is not triggered
## How to review
1. Setup and run the app as per README instructions
2. Browse to [http://localhost:5000/notes](the notes page)
3. Click to edit an existing note
4. Add the words `extra line of text` at the end of the note
5. Press Save
6. Click on 'undo'
7. See that no yellow border or change of text from rendered HTML to Markdown is visible
## Who can review

Not @andyhd
