### PR TITLE
Enable adding and editing notes when JS disabled

### DIFF
--- a/app/blueprints/notes/views.py
+++ b/app/blueprints/notes/views.py
@@ -67,10 +67,13 @@ def undo(id):
     return redirect(url_for('.list'))
 
 
-@notes.route('/notes/<id>/edit', methods=['POST'])
+@notes.route('/notes/<id>/edit', methods=['GET', 'POST'])
 @login_required
 def edit(id):
     note = Note.get_or_404(id=id, author=current_user)
+
+    if request.method == 'GET':
+        return render_template('notes/edit.html', note=note)
 
     note.update(request.form['content'])
     return redirect(url_for('.list'))

--- a/app/static/sass/notes/_notes.scss
+++ b/app/static/sass/notes/_notes.scss
@@ -140,7 +140,8 @@
   margin-top: $gutter;
   padding: 0 $gutter;
 
-  > li {
+  .note {
+    display: block;
     margin: 0 auto $gutter;
     max-width: 30em;
     padding: $gutter-half;
@@ -240,8 +241,15 @@
     box-shadow: none;
     padding: 8px 10px 5px;
     border-radius: 2px;
+    display: inline-block;
+  }
+}
+
+.js-enabled .add-note-form {
+  button {
     display: none;
   }
+
   &.active {
     border: 4px solid $focus-colour;
     button {
@@ -283,6 +291,7 @@
 }
 
 .js-enabled {
+
   .note.edit-mode {
     border: 4px solid $focus-colour;
     .note-form {

--- a/app/templates/notes/edit.html
+++ b/app/templates/notes/edit.html
@@ -17,26 +17,10 @@
 {% block body_content %}
 
   <div class="test">
-    <a href="{{ url_for('notes.list') }}" class="link-back">Back to all notes</a>
-
-    <h1 class="heading-xlarge">
-      <span class="heading-secondary">Searching your notes</span>
-      <div class="editable search-term">{{ search_term }}</div>
-    </h1>
+    <h1 class="heading-large">Edit your Note</h1>
   </div>
 
-  <section class="notes-main">
-    <p class="result-info">
-      <span class="result-count">{{ result_count }}</span>
-      notes matching <strong>{{ search_term }}</strong>
-    </p>
-  </section>
-
-  {% include "partial/notes_list.html" %}
-
-  <div class="test">
-    <a class="more-link" href="#search-term">change search</a>
-  </div>
+  {% include "partial/edit_note_form.html" %}
 
 {% endblock %}
 

--- a/app/templates/notes/list.html
+++ b/app/templates/notes/list.html
@@ -16,21 +16,10 @@
 
 {% block body_content %}
 
-  <div class="sign-out"></div>
-
   <div class="test">
     <h1 class="heading-large">Notes</h1>
 
-    {% if email_tip_visible %}
-    <div class="message-box">
-      <h3 class="heading-small">You can also email notes in to the service</h3>
-      <p>
-        Use <a href="mailto:{{ inbox_email }}">{{ inbox_email }}</a>.
-        Check your settings for more details.
-      </p>
-      <span class="dismiss"><a href="{{ url_for('notes.dismiss_tip') }}">Dismiss</a></span>
-    </div>
-    {% endif %}
+    {% include "partial/email_tip.html" %}
 
   </div>
 
@@ -39,11 +28,7 @@
     <button class="button">Save</button>
   </form>
 
-  <ul class="notes-list">
-  {% for note in notes %}
-    {% include "notes/note.html" %}
-  {% endfor %}
-  </ul>
+  {% include "partial/notes_list.html" %}
 
   <div class="test">
     <a class="more-link" href="">load more</a>

--- a/app/templates/notes/note.html
+++ b/app/templates/notes/note.html
@@ -1,7 +1,10 @@
-<li class="note editOnClick" itemscope itemtype="http://schema.org/CreativeWork" data-id="{{ note.id }}">
+<div itemscope itemtype="http://schema.org/CreativeWork" data-id="{{ note.id }}">
   <section class="text rendered-markdown rendered-note" itemprop="text">
     {{ note.truncated }}
   </section>
+  <noscript>
+    <a href="{{ note.edit_url }}" class="edit-link">Edit</a>
+  </noscript>
   <section>
     <form action="{{ note.edit_url }}" method="post" class="form note-form">
       <textarea name="content" id="content" class="expandToFitContent" rows="1" placeholder="Write a note &hellip;">{{ note.content }}</textarea>
@@ -19,4 +22,4 @@
   {% if note.is_email %}
   <div class="email-flag">Email</div>
   {% endif %}
-</li>
+</div>

--- a/app/templates/partial/edit_note_form.html
+++ b/app/templates/partial/edit_note_form.html
@@ -1,0 +1,4 @@
+<form action="{{ note.edit_url }}" method="post" class="form note-form add-note-form active">
+  <textarea name="content" placeholder="Write a note &hellip;">{{ note.content }}</textarea>
+  <button class="button">Save</button>
+</form>

--- a/app/templates/partial/email_tip.html
+++ b/app/templates/partial/email_tip.html
@@ -1,0 +1,10 @@
+{% if email_tip_visible %}
+<div class="message-box">
+  <h3 class="heading-small">You can also email notes in to the service</h3>
+  <p>
+    Use <a href="mailto:{{ inbox_email }}">{{ inbox_email }}</a>.
+    Check your settings for more details.
+  </p>
+  <span class="dismiss"><a href="{{ url_for('notes.dismiss_tip') }}">Dismiss</a></span>
+</div>
+{% endif %}

--- a/app/templates/partial/notes_list.html
+++ b/app/templates/partial/notes_list.html
@@ -1,0 +1,7 @@
+<ul class="notes-list">
+  {% for note in notes %}
+  <li class="note editOnClick">
+    {% include "notes/note.html" %}
+  </li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## What
- Refactored SCSS to unhide save button on add note form if JS is disabled
- Added a `noscript` tag to note template containing an "Edit" link
- Added new "Edit your Note" view and template
## How to review
1. Run app as per README instructions
2. Login and browse to [the notes page](http://localhost:5000/notes)
3. Disable Javascript in your browser and reload the page
4. See the "Save" button appear in the "Write a note..." form at the top of the page
5. Write a note, click "Save", see your note at the top of the list
6. Click on the "Edit" link in the note
7. Be taken to "Edit your Note" page and edit your note in the form presented
8. Click "Save" and see your edited note at the top of the list
## Who can review

Not @andyhd

Fixes https://trello.com/c/iQWqYwI0
