### PR TITLE
Display note content without truncation

### DIFF
--- a/app/blueprints/notes/models.py
+++ b/app/blueprints/notes/models.py
@@ -110,10 +110,14 @@ class Note(db.Model, GetOr404Mixin, GetOrCreateMixin):
         return Note.query.search(term, sort=True)
 
     @property
-    def truncated(self):
+    def rendered(self):
         markdown = current_app.jinja_env.filters['markdown']
+        return markdown(self.content)
+
+    @property
+    def truncated(self):
         truncate = current_app.jinja_env.filters['truncate_html']
-        return truncate(markdown(self.content), 250, end=" \u2026")
+        return truncate(self.rendered, 250, end=" \u2026")
 
     @property
     def edit_url(self):

--- a/app/static/js/notesapp.js
+++ b/app/static/js/notesapp.js
@@ -39,6 +39,7 @@
       event.stopPropagation();
     });
     $el.find('.close-btn').on('click', deactivate);
+    $el.find('.cancel').on('click', deactivate);
     $el.on('click', edit);
   }
 

--- a/app/static/sass/notes/_notes.scss
+++ b/app/static/sass/notes/_notes.scss
@@ -285,12 +285,22 @@
     outline: none;
   }
 
-  button {
+  .button {
     margin-top: 15px;
     margin-bottom: 0;
     box-shadow: none;
     padding: 8px 10px 5px;
     border-radius: 2px;
+  }
+
+  .cancel {
+    background-color: $grey-3;
+    color: $black;
+
+    &:hover,
+    &:active {
+      background-color: $grey-2;
+    }
   }
 
   .close-btn {

--- a/app/templates/notes/note.html
+++ b/app/templates/notes/note.html
@@ -1,8 +1,7 @@
 <div itemscope itemtype="http://schema.org/CreativeWork" data-id="{{ note.id }}">
-  <button class="close-btn">close</button>
 
   <section class="text rendered-markdown rendered-note" itemprop="text">
-    {{ note.truncated }}
+    {{ note.rendered }}
   </section>
 
   <section class="note-edit-controls">
@@ -14,6 +13,7 @@
     <form action="{{ note.edit_url }}" method="post" class="form note-form">
       <textarea name="content" id="content" class="expandToFitContent" rows="1" placeholder="Write a note &hellip;">{{ note.content }}</textarea>
       <button class="button">Save</button>
+      <input class="cancel button" type="reset" value="Cancel">
       <div><input type="text" placeholder="add extra tags &hellip;" name="tags"></div>
     </form>
 


### PR DESCRIPTION
## What
- Disabled note content truncation in the template
## How to review
1. Run the app as per README instructions
2. Browse to [the notes page](http://localhost:5000/notes)
3. Write a note with more than 250 characters, eg:
   
   ```
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   * All work and no play makes Jack a dull boy
   ```
4. See that the note is displayed in full and does not end with an ellipsis (&hellip;)
## Who can review

Not @andyhd

Fixes https://trello.com/c/dKbiN2Cf
