### PR TITLE
Add manage tags page

### DIFF
--- a/app/blueprints/notes/models.py
+++ b/app/blueprints/notes/models.py
@@ -95,7 +95,7 @@ class Note(db.Model, GetOr404Mixin, GetOrCreateMixin):
         db.session.commit()
 
     def add_tag(self, tag_name):
-        if not self.has_tag(tag_name):
+        if tag_name and not self.has_tag(tag_name):
             self.tags.append(Tag(name=sanitize(tag_name), author=self.author))
             db.session.add(self)
             db.session.commit()
@@ -188,9 +188,14 @@ class NoteHistory(db.Model):
 class Tag(db.Model, GetOr404Mixin):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String)
+    namespace = db.Column(db.String)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'))
     author = db.relationship('User', backref='tags')
 
     @property
     def url(self):
         return url_for('notes.by_tag', tag=self.name)
+
+    @property
+    def usage_count(self):
+        return len(self.notes)

--- a/app/blueprints/notes/views.py
+++ b/app/blueprints/notes/views.py
@@ -13,7 +13,7 @@ from flask import (
     url_for)
 from flask_login import current_user
 from flask_security import login_required
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 
 from app.blueprints.notes.email_tip import EmailTip
 from app.blueprints.notes.models import Note, Tag
@@ -32,6 +32,22 @@ def list():
     email_tip.incr_times_seen()
 
     return render_template('notes/list.html', notes=notes)
+
+
+@notes.route('/tags')
+@login_required
+def tags():
+    tags = Tag.query.filter(or_(
+        Tag.author == current_user,
+        Tag.author == None))  # noqa
+
+    context = {
+        'user_tags': tags.filter(Tag.namespace == None).all(),  # noqa
+        'competency_tags': tags.filter(Tag.namespace == 'Competency').all(),
+        'objective_tags': tags.filter(Tag.namespace == 'Objective').all(),
+    }
+
+    return render_template('notes/tags.html', **context)
 
 
 @notes.route('/notes/tag/<tag>')

--- a/app/templates/notes/tags.html
+++ b/app/templates/notes/tags.html
@@ -1,0 +1,55 @@
+{% extends "base.html" %}
+
+{% block endhead %}
+  {% assets "css_notes" %}
+    <link rel="stylesheet" href="{{ ASSET_URL }}">
+  {% endassets %}
+{% endblock %}
+
+{% macro tag_list(title, tags, add_tag_form=False) %}
+  <div>
+
+    <h2 class="heading-medium">{{ title }}</h2>
+
+    <ul class="tag-list-block">
+    {% for tag in tags %}
+      <li class="note-tag{% if tag.usage_count %} note-tag--count{% endif %}">
+        <a href="{{ tag.url }}">{{ tag.name }}</a>
+        {% if tag.usage_count %}
+          <span class="tag-quantity">{{ tag.usage_count }}</span>
+        {% endif %}
+      </li>
+    {% endfor %}
+    </ul>
+
+    {% if add_tag_form %}
+    <details class="section">
+      <summary>Create new tags</summary>
+    </details>
+    {% endif %}
+
+  </div>
+{% endmacro %}
+
+{% block body_content %}
+
+  <div class="test">
+    <a href="{{ url_for('notes.list') }}" class="link-back">Back to all notes</a>
+
+    <h1 class="heading-large">
+      Manage your tags
+    </h1>
+    <p class="lede">
+      Use this page to manage the tags you use to organise your notes
+    </p>
+  </div>
+
+  <section class="notes-section">
+
+    {{ tag_list("Your tags", user_tags, add_tag_form=True) }}
+
+    {{ tag_list("Default tags", competency_tags) }}
+
+  </section>
+
+{% endblock %}

--- a/tests/spec/test_add_note.py
+++ b/tests/spec/test_add_note.py
@@ -19,7 +19,7 @@ def soup(follow_redirect):
     return BeautifulSoup(follow_redirect.get_data(as_text=True), 'html.parser')
 
 
-@pytest.mark.use_fixtures('db_session', 'logged_in')
+@pytest.mark.usefixtures('db_session', 'logged_in')
 class WhenAddingANewNote(object):
 
     def it_redirects_to_the_list_view(self, form_submit):

--- a/tests/spec/test_manage_tags.py
+++ b/tests/spec/test_manage_tags.py
@@ -1,0 +1,67 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+import pytest
+
+from app.blueprints.notes.models import Tag
+
+
+competency_names = set([
+    'Delivering Value for Money',
+    'Seeing the Big Picture',
+    'Changing and Improving',
+    'Making Effective Decisions',
+    'Leading and Communicating',
+    'Collaborating and Partnering',
+    'Building Capability for All',
+    'Achieving Commercial Outcomes',
+    'Managing a Quality Service',
+    'Delivering at Pace'])
+
+
+@pytest.fixture
+def tags(db_session, test_user):
+
+    def make_tag(name):
+        tag = Tag(name=name, author=test_user)
+        db_session.add(tag)
+        db_session.commit()
+        return tag
+
+    return list(map(make_tag, ['foo', 'bar', 'quux']))
+
+
+@pytest.fixture
+def response(client, logged_in):
+    return client.get(url_for('notes.tags'))
+
+
+@pytest.fixture
+def soup(response):
+    return BeautifulSoup(response.get_data(as_text=True), 'html.parser')
+
+
+class WhenOnTheManageTagsPage(object):
+
+    def it_shows_all_user_tags_in_a_section(self, tags, soup):
+        tag_lists = soup.find_all(class_='tag-list-block')
+        assert len(tag_lists) == 2
+
+        user_tags = tag_lists[0]
+        assert user_tags.previous_sibling.previous_sibling.text == 'Your tags'
+
+        user_tags = user_tags.find_all(class_='note-tag')
+        assert len(user_tags) == 3
+
+    def it_shows_all_default_tags_in_a_section(self, tags, soup):
+        tag_lists = soup.find_all(class_='tag-list-block')
+        assert len(tag_lists) == 2
+
+        default_tags = tag_lists[1]
+        title = default_tags.previous_sibling.previous_sibling.text
+        assert title == 'Default tags'
+
+        default_tags = default_tags.find_all(class_='note-tag')
+        assert len(default_tags) == 10
+
+        default_tags = set(map(lambda x: x.find('a').text, default_tags))
+        assert competency_names.issubset(default_tags)


### PR DESCRIPTION
## What
- Add Manage Tags page listing all of a user's tags
- Prevented adding an empty tag
- Added `usage_count` attribute to `Tag` model
## How to review
1. Setup the app per README instructions
2. Browse to the [manage tags page](http://localhost:5000/tags)
3. See your tags listed with usage counts
## Who can review

Not @andyhd

Fixes https://trello.com/c/4bJOzNs5
